### PR TITLE
Fix send id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -201,7 +201,9 @@ export class IFrameEthereumProvider extends EventEmitter<
     | JsonRpcSucessfulResponseMessage<TResult>
     | JsonRpcErrorResponseMessage<TErrorData>
   > {
-    const id = Number.isNaN(optionalId as any) ? getUniqueId() : optionalId;
+    const id = Number.isNaN(optionalId as any)
+      ? getUniqueId()
+      : (optionalId as number);
 
     const payload: JsonRpcRequestMessage = {
       jsonrpc: JSON_RPC_VERSION,

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,12 +195,14 @@ export class IFrameEthereumProvider extends EventEmitter<
    */
   private async execute<TParams, TResult, TErrorData>(
     method: string,
-    params?: TParams
+    params?: TParams,
+    optionalId?: number
   ): Promise<
     | JsonRpcSucessfulResponseMessage<TResult>
     | JsonRpcErrorResponseMessage<TErrorData>
   > {
-    const id = getUniqueId();
+    const id = Number.isNaN(optionalId as any) ? getUniqueId() : optionalId;
+
     const payload: JsonRpcRequestMessage = {
       jsonrpc: JSON_RPC_VERSION,
       id,
@@ -274,14 +276,18 @@ export class IFrameEthereumProvider extends EventEmitter<
    * @param callback callback to be called when the provider resolves
    */
   public async sendAsync(
-    payload: { method: string; params?: any[] },
+    payload: { method: string; params?: any[]; id?: number },
     callback: (
       error: string | null,
       result: { method: string; params?: any[]; result: any } | any
     ) => void
   ): Promise<void> {
     try {
-      const result = await this.execute(payload.method, payload.params);
+      const result = await this.execute(
+        payload.method,
+        payload.params,
+        payload.id
+      );
 
       callback(null, result);
     } catch (error) {


### PR DESCRIPTION
When using `sendAsync`, the `payload` parameter may contain an existing object `id`. I've added a check for if the id is set and to use it instead of generating a new id.